### PR TITLE
Ensure $PIDS and $LOGS directories are writable

### DIFF
--- a/bin/mongroup
+++ b/bin/mongroup
@@ -86,8 +86,16 @@ read_config() {
     abort $PIDS directory doesn\'t exist
   fi
 
+  if [ ! -w $PIDS ]; then
+    abort $PIDS directory is not writable
+  fi
+
   if [ ! -d $LOGS ]; then
     abort $LOGS directory doesn\'t exist
+  fi
+
+  if [ ! -w $LOGS ]; then
+    abort $LOGS directory is not writable
   fi
 }
 


### PR DESCRIPTION
Without these paths being writable, mon will launch, but won't write it's own
pidfile, and mongroup will be unable to communciate with the mon processes it
creates.
